### PR TITLE
added mxcube video streamer support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     ports:
      - "8081:8081"  # MXCuBE
      - "5000:5000"  # Dashboard
+     - "8000:8000" # video-streamer
     environment:
      - TANGO_HOST=tango-cs:10000
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
      - TANGO_HOST=tango-cs:10000
     build:
       context: mxcube
+    volumes:
+      - ./mxcube/video-streamer_config.json:/app/video-streamer_config.json
   b-micromax-md3-pc:
     build:
       context: b-micromax-md3-pc

--- a/mxcube/Dockerfile
+++ b/mxcube/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.5.6
+FROM mambaorg/micromamba:1.5.10
 
 USER root
 RUN apt-get update
@@ -22,6 +22,8 @@ RUN micromamba install --name base --channel conda-forge \
     itango=0.1.9 \
     redis-server=7.0.11 \
     circus=0.18.0 \
+    # for video streamer
+    ffmpeg \
     # install as conda package, so pip does not try to compile it
     python-ldap=3.4.3 \
     # for building front-end \
@@ -56,6 +58,7 @@ RUN /opt/conda/envs/dashboard/bin/write_mxcube_config
 
 WORKDIR /app
 
+
 # clone 'core' repository on maxiv-develop branch
 RUN git clone --branch maxiv-develop https://gitlab.maxiv.lu.se/kits-maxiv/mxcube/mxcubecore.git core
 
@@ -64,6 +67,7 @@ RUN git clone --branch maxiv-develop https://gitlab.maxiv.lu.se/kits-maxiv/mxcub
 
 RUN /opt/conda/bin/pip install -e web
 RUN /opt/conda/bin/pip install -e core
+
 
 # build front-end
 WORKDIR /app/web/ui

--- a/mxcube/circus.conf
+++ b/mxcube/circus.conf
@@ -9,6 +9,12 @@ copy_env = True
 working_dir = /app
 hooks.before_start = tango_ping.wait_for_tango
 
+[watcher:video-streamer]
+cmd = /opt/conda/bin/video-streamer -c video-streamer_config.json
+copy_env = True
+working_dir = /app
+hooks.before_start = tango_ping.wait_for_tango
+
 [env:mxcube]
 PYTHONPATH = $PYTHONPATH:/opt/circus/
 

--- a/mxcube/video-streamer_config.json
+++ b/mxcube/video-streamer_config.json
@@ -1,0 +1,11 @@
+{
+  "sources": {
+    "0.0.0.0:8000": {
+      "input_uri": "tango://b-micromax-md3-pc:9999/md/oav/bzoom#dbase=no",
+      "size": [1224, 1024],
+      "quality": 4,
+      "format": "MPEG1",
+      "hash": "md3video"
+    }
+  }
+}


### PR DESCRIPTION
Adds [mxcube video-streamer](https://github.com/mxcube/video-streamer/tree/main)

It will be started by mxcubecore, as a subprocess, similarly to [this](https://github.com/mxcube/mxcubecore/blob/develop/mxcubecore/HardwareObjects/mockup/MDCameraMockup.py)

It also required change to the mocked MD3 video device server. Video streamer works under assumption that `video_last_image_counter` changes independently of wether the image has been polled or not. Currently the counter is increment only when we poll the image.