### PR TITLE
Adds `DirectBeamEnabled` attribute

### DIFF
--- a/b-micromax-md3-pc/exporter.py
+++ b/b-micromax-md3-pc/exporter.py
@@ -274,6 +274,7 @@ class MD3Up:
             ),
             "DetectorDistance": Attribute(700.0, DOUBLE),
             "DetectorState": Attribute("Ready", STATE),
+            "DirectBeamEnabled": Attribute(False, BOOLEAN),
             "FastShutterIsOpen": Attribute(False, BOOLEAN),
             "FrontLightFactor": Attribute(0.9, DOUBLE),
             "FrontLightIsOn": Attribute(False, BOOLEAN),


### PR DESCRIPTION
Adds `DirectBeamEnabled` attribute.
Also implements some of it's behaviours. That is:
1. it disallows moving beamstop out of `BEAM` position when fast shutter is open
2. it disallows opening fast shutter when beamstop is not at `BEAM` position.

For these 2 points above, I've made a change to `Attribute` class. 
It takes a callback, that is supposed to validate / transform value when setting value. 
This allows the checks to happen when the value is assigned. It could also allow stuff like normalizing `omega` angle to [0,360) range, during assignment (but that's for a different PR :smiley_cat:)

As the `DirectBeamEnabled` is not yet implemented in MXCuBE (and changing it directly would also not be possible), I tested it using this small script below.
```python
```python
#!/usr/bin/env python3
import socket
import sys

HOST = "b-micromax-md3-pc"
PORT = 9001


def usage():
    print(f"{sys.argv[0]} <attribute_name> <value>")
    sys.exit()


def get_command():
    if len(sys.argv) != 3:
        usage()
    attribute_name, value = sys.argv[1:]
    return f"\x02WRTE {attribute_name} {value}\x03".encode()


def main():
    command = get_command()
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
        s.connect((HOST, PORT))
        s.sendall(command)
        while True:
            print(s.recv(1024))

main()
```