### PR TITLE
MicroMAX: drop 'MicroMAX' part from MXCuBE config file path

### DIFF
--- a/biomax/mxcube/Dockerfile
+++ b/biomax/mxcube/Dockerfile
@@ -55,7 +55,7 @@ RUN git clone --depth 8 --branch maxiv-develop https://gitlab.maxiv.lu.se/kits-m
 #
 # Disable uploads to SciCat, avoid uploading data when running in the emulator.
 #
-RUN cd /app/conf/BioMAX && \
+RUN cd /app/conf && \
     sed -i '/proxy_address/d' lims.yaml && \
     sed -i 's/scicat_enabled: true/scicat_enabled: false/' collect.yaml
 
@@ -77,7 +77,7 @@ RUN mv /app/web/ui/build /opt/mxcube
 # 'Expand' the MXCuBE server config file.
 # Put the stream URL that works inside the emulator.
 #
-RUN cd /app/conf/BioMAX/mxcube-web/ && \
+RUN cd /app/conf/mxcube-web/ && \
     sed 's/VIDEO_STREAM_URL:.*/VIDEO_STREAM_URL: ws:\/\/localhost:8082\/ws/' server.yaml.j2 > server.yaml
 
 #

--- a/biomax/mxcube/circus.conf
+++ b/biomax/mxcube/circus.conf
@@ -4,7 +4,7 @@ cmd = /opt/conda/bin/redis-server
 working_dir = /tmp
 
 [watcher:mxcube]
-cmd = /app/web/mxcubeweb-server --repository /app/conf/BioMAX --static-folder /opt/mxcube/build
+cmd = /app/web/mxcubeweb-server --repository /app/conf --static-folder /opt/mxcube/build
 copy_env = True
 working_dir = /app
 hooks.before_start = tango_ping.wait_for_tango
@@ -13,6 +13,6 @@ hooks.before_start = tango_ping.wait_for_tango
 PYTHONPATH = $PYTHONPATH:/opt/circus/
 
 [watcher:video-streamer]
-cmd = /opt/conda/bin/video-streamer --config /app/conf/BioMAX/video-streamer/config.json
+cmd = /opt/conda/bin/video-streamer --config /app/conf/video-streamer/config.json
 copy_env = True
 hooks.before_start = tango_ping.wait_for_tango

--- a/micromax/mxcube/Dockerfile
+++ b/micromax/mxcube/Dockerfile
@@ -37,7 +37,7 @@ RUN micromamba install --name base --channel conda-forge \
 #
 
 RUN micromamba create --name dashboard
-RUN micromamba install --name dashboard app-micromax-dashboard=0.8.0
+RUN micromamba install --name dashboard app-micromax-dashboard=0.10.0
 
 # add emulator specific dashboard configuration
 COPY dboard_config.py /opt/dashboard/config.py

--- a/micromax/mxcube/circus.conf
+++ b/micromax/mxcube/circus.conf
@@ -4,7 +4,7 @@ cmd = /opt/conda/bin/redis-server
 working_dir = /tmp
 
 [watcher:mxcube]
-cmd = /app/web/mxcubeweb-server --repository /app/conf/MicroMAX --static-folder /opt/mxcube/build
+cmd = /app/web/mxcubeweb-server --repository /app/conf --static-folder /opt/mxcube/build
 copy_env = True
 working_dir = /app
 hooks.before_start = tango_ping.wait_for_tango
@@ -13,7 +13,7 @@ hooks.before_start = tango_ping.wait_for_tango
 PYTHONPATH = $PYTHONPATH:/opt/circus/
 
 [watcher:video-streamer]
-cmd = /opt/conda/bin/video-streamer --config /app/conf/MicroMAX/video-streamer/config.json
+cmd = /opt/conda/bin/video-streamer --config /app/conf/video-streamer/config.json
 copy_env = True
 hooks.before_start = tango_ping.wait_for_tango
 

--- a/micromax/mxcube/dboard_config.py
+++ b/micromax/mxcube/dboard_config.py
@@ -1,4 +1,4 @@
-MXCUBE_CONFIG_DIR="/app/conf/MicroMAX"
+MXCUBE_CONFIG_DIR="/app/conf"
 MXCUBE_START_COMMAND="/opt/conda/bin/circusctl start mxcube"
 MXCUBE_STOP_COMMAND="/opt/conda/bin/circusctl stop mxcube"
 VIDEO_STREAM_PROTOCOL="ws"


### PR DESCRIPTION
No need to put MXCuBE configuration files in /app/conf/MicroMAX. We can use shorter path /app/conf.